### PR TITLE
Fix: roomlist after exit

### DIFF
--- a/src/main/java/pointer/Pointer_Spring/room/repository/RoomMemberRepository.java
+++ b/src/main/java/pointer/Pointer_Spring/room/repository/RoomMemberRepository.java
@@ -24,7 +24,7 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
     List<RoomMember> findAllByRoom_RoomIdAndStatusEquals(Long roomId, int status);
     //List<RoomMember> findAllByUser_UserIdAndRoom_StatusEqualsAndPrivateRoomNmContaining(Long roomId, int status, String kwd);
     List<RoomMember> findAllByUserUserIdAndPrivateRoomNmContainingAndRoom_StatusEqualsOrderByRoom_UpdatedAtAsc(Long userId, String kwd, int status);
-    List<RoomMember> findAllByUserUserIdAndRoom_StatusEqualsOrderByRoom_UpdatedAtAsc(Long userId, int status);
+    List<RoomMember> findAllByUserUserIdAndRoom_StatusEqualsAndStatusOrderByRoom_UpdatedAtAsc(Long userId, int roomStatus, int roomMemStatus);
     List<RoomMember> findAllByRoomAndUserIsQuestionRestrictedAndStatusEquals(Room room, boolean isQuestionRestricted, int status);
     List<RoomMember> findAllByRoomAndUserIsHintRestrictedAndStatusEquals(Room room, boolean isHintRestricted, int status);
     Optional<RoomMember> findByRoom_RoomIdAndUser_UserIdAndStatus(Long roomId, Long userId, int status);

--- a/src/main/java/pointer/Pointer_Spring/room/service/RoomServiceImpl.java
+++ b/src/main/java/pointer/Pointer_Spring/room/service/RoomServiceImpl.java
@@ -69,7 +69,7 @@ public class RoomServiceImpl implements RoomService {
         List<RoomDto.ListRoom> roomListDto = new ArrayList<>();
         Long userId = userPrincipal.getId();
         if (kwd == null) {
-            roomListDto = roomMemberRepository.findAllByUserUserIdAndRoom_StatusEqualsOrderByRoom_UpdatedAtAsc(userId,  STATUS)
+            roomListDto = roomMemberRepository.findAllByUserUserIdAndRoom_StatusEqualsAndStatusOrderByRoom_UpdatedAtAsc(userId,  STATUS, STATUS)
                     .stream()
                     .map(roomMember -> {
                         Room room = roomMember.getRoom();
@@ -92,7 +92,7 @@ public class RoomServiceImpl implements RoomService {
                     .sorted(Comparator.comparing(room -> room.getLimitedAt(), Comparator.reverseOrder()))
                     .toList();
         } else {
-            roomListDto = roomMemberRepository.findAllByUserUserIdAndRoom_StatusEqualsOrderByRoom_UpdatedAtAsc(userId, STATUS).stream()
+            roomListDto = roomMemberRepository.findAllByUserUserIdAndRoom_StatusEqualsAndStatusOrderByRoom_UpdatedAtAsc(userId, STATUS, STATUS).stream()
                     .filter(roomMember -> {
                         Room room = roomMember.getRoom();
                         Optional<Question> latestQuestion = room.getQuestions().stream()


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 리펙토링
- [ ] 응답 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
room-exit -> main

### 변경 사항
room 나간 후에도 목록에 남는 오류 수정(roomMember status 비교까지 추가)